### PR TITLE
PHPStan support for union methods

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2438,7 +2438,7 @@ class Builder implements BuilderContract
     /**
      * Add a union statement to the query.
      *
-     * @param  \Illuminate\Database\Query\Builder|\Closure  $query
+     * @param  \Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder|\Closure  $query
      * @param  bool  $all
      * @return $this
      */
@@ -2458,7 +2458,7 @@ class Builder implements BuilderContract
     /**
      * Add a union all statement to the query.
      *
-     * @param  \Illuminate\Database\Query\Builder|\Closure  $query
+     * @param  \Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder|\Closure  $query
      * @return $this
      */
     public function unionAll($query)


### PR DESCRIPTION
The union method is supports EloquentBuilder, but an error occurs because there is no description.

```php
$first = User::where('id',8);

$users = User::where('id',2)->union($first)->get();
```

```
Parameter #1 $query of method Illuminate\Database\Eloquent\Builder<Illuminate\Database\Eloquent\Model>::union() expects Closure|Illuminate\Database\Query\Builder, Illuminate\Database\Eloquent\Builder given.
```